### PR TITLE
NEW Adding getHandler to allow access to DynamoDBHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ If you wish to store sessions in DynamoDB, set the following environment variabl
 	define('AWS_REGION_NAME', 'ap-southeast-2');
 	
 Once these are in place, this module will configure DynamoDB and register that as the session handler.
-You will **need** to create the specified table using the AWS DynamoDB console for the region.
+
+To create a DynamoDB session table you can execute the following code:
+
+```php
+DynamoDbSession::get()->getHandler()->createSessionsTable(5,5);
+```
+
+See http://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html#create-a-table-for-storing-your-sessions
+for more information about `createSessionsTable`
 
 ## Using DynamoDB outside of AWS
 

--- a/code/model/DynamoDbSession.php
+++ b/code/model/DynamoDbSession.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Session\SessionHandler;
 
@@ -21,6 +19,15 @@ class DynamoDbSession
      * @var SessionHandler
      */
     protected $handler;
+
+    /**
+     * Getter for SessionHandler
+     *
+     * @return SessionHandler
+     */
+    public function getHandler() {
+        return $this->handler;
+    }
 
     /**
      * Get an instance of DynamoDbSession configured from the environment if available.


### PR DESCRIPTION
I've added a `getHandler` function as this allows users to do:

``` php
$dynamoSession = DynamoDbSession::get();
$dynamoSession->getHandler()->createSessionsTable(5,5);
```

Which means that devs can easily set up session tables (see docs diff)
