### PR TITLE
FIX AWS_DYNAMODB_SESSION_LIFETIME has no effect

### DIFF
--- a/code/model/DynamoDbSession.php
+++ b/code/model/DynamoDbSession.php
@@ -50,10 +50,6 @@ class DynamoDbSession
                 $dynamoOptions['credentials.cache'] = true;
             }
 
-            if (defined('AWS_DYNAMODB_SESSION_LIFETIME')) {
-                $dynamoOptions['session_lifetime'] = AWS_DYNAMODB_SESSION_LIFETIME;
-            }
-
             return new DynamoDbSession($dynamoOptions, AWS_DYNAMODB_SESSION_TABLE);
         }
 
@@ -62,25 +58,31 @@ class DynamoDbSession
 
     public function __construct($options, $table)
     {
-        // refer to the Session class to find the session timeout value (if it exists)
-        // in terms of DynamoDB, session_lifetime is the time to mark the inactive
-        // session to be garbage collected
-        // if {@link GarbageCollectSessionCronTask} is running periodically on your
-        // server (via the silverstripe-crontask module), then the inactive session
-        // will get removed from the DynamoDB session table.
-        if (!isset($options['session_lifetime'])) {
-            $timeout = Config::inst()->get('Session', 'timeout');
-            if ($timeout != null) {
-                $options['session_lifetime'] = $timeout;
-            }
-        }
-
         $this->client = DynamoDbClient::factory($options);
         $this->table = $table;
         $this->handler = SessionHandler::factory(array(
             'dynamodb_client' => $this->client,
             'table_name' => $this->table,
+            'session_lifetime' => $this->getSessionLifetime(),
         ));
+    }
+
+    /**
+     * check the AWS constant or refer to the Session class to find the session timeout value (if it exists) in terms
+     * of DynamoDB, session_lifetime is the time to mark the inactive session to be garbage collected
+     * if {@link GarbageCollectSessionCronTask} is running periodically on your server (via the silverstripe-crontask
+     * module), then the inactive session will get removed from the DynamoDB session table.
+     *
+     * @return int The session lifetime
+     */
+    protected function getSessionLifetime() {
+        if (defined('AWS_DYNAMODB_SESSION_LIFETIME')) {
+            return AWS_DYNAMODB_SESSION_LIFETIME;
+        }
+        if (($timeout = (int)Config::inst()->get('Session', 'timeout')) > 0) {
+            return $timeout;
+        }
+        return (int) ini_get('session.gc_maxlifetime');
     }
 
     /**

--- a/code/model/DynamoDbSession.php
+++ b/code/model/DynamoDbSession.php
@@ -50,7 +50,7 @@ class DynamoDbSession
                 $dynamoOptions['credentials.cache'] = true;
             }
 
-            return new DynamoDbSession($dynamoOptions, AWS_DYNAMODB_SESSION_TABLE);
+            return new static($dynamoOptions, AWS_DYNAMODB_SESSION_TABLE);
         }
 
         return null;


### PR DESCRIPTION
The value for session_lifetime was being sent to the wrong factory method and, thus, was having no effect on session lifetimes.

This fix patches that.
