### PR TITLE
Using a different caching method

### DIFF
--- a/code/model/DynamoDbSession.php
+++ b/code/model/DynamoDbSession.php
@@ -55,7 +55,7 @@ class DynamoDbSession
                 // cache credentials when IAM fetches the credentials from EC2 metadata service
                 // this will use doctrine/cache (included via composer) to do the actual caching into the filesystem
                 // http://docs.aws.amazon.com/aws-sdk-php/v2/guide/credentials.html#instance-profile-credentials
-                $dynamoOptions['credentials'] = new DoctrineCacheAdapter(new FilesystemCache('/tmp/cache'));
+                $dynamoOptions['credentials'] = new DoctrineCacheAdapter(new FilesystemCache(TEMP_PATH));
             }
 
             return new static($dynamoOptions, AWS_DYNAMODB_SESSION_TABLE);

--- a/code/model/DynamoDbSession.php
+++ b/code/model/DynamoDbSession.php
@@ -3,7 +3,7 @@
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\SessionHandler;
 use Aws\DoctrineCacheAdapter;
-use Doctrine\Common\Cache\ApcuCache;
+use Doctrine\Common\Cache\FilesystemCache;
 
 class DynamoDbSession
 {
@@ -53,9 +53,9 @@ class DynamoDbSession
                 $dynamoOptions['credentials']['secret'] = AWS_SECRET_KEY;
             } else {
                 // cache credentials when IAM fetches the credentials from EC2 metadata service
-                // this will use doctrine/cache (included via composer) to do the actual caching into APCu
-                // http://docs.aws.amazon.com/aws-sdk-php/guide/latest/performance.html#cache-instance-profile-credentials
-                $dynamoOptions['credentials'] = new DoctrineCacheAdapter(new ApcuCache());
+                // this will use doctrine/cache (included via composer) to do the actual caching into the filesystem
+                // http://docs.aws.amazon.com/aws-sdk-php/v2/guide/credentials.html#instance-profile-credentials
+                $dynamoOptions['credentials'] = new DoctrineCacheAdapter(new FilesystemCache('/tmp/cache'));
             }
 
             return new static($dynamoOptions, AWS_DYNAMODB_SESSION_TABLE);


### PR DESCRIPTION
I was getting the following error with the ApcuCache, due to not actaully having APC installed..

```
PHP Fatal error:  Call to undefined function Doctrine\Common\Cache\apcu_fetch() in /var/www/html/vendor/doctrine/cache/lib/Doctrine/Common/Cache/ApcuCache.php on line 36"
```

It is suggested to simply use a the filesystem cache adapter here http://docs.aws.amazon.com/aws-sdk-php/v2/guide/credentials.html#instance-profile-credentials

It also appears that APC in PHP is no longer maintained http://us2.php.net/manual/en/intro.apc.php

Looking here http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/caching.html and also an output the cache adapters available in code it looks like the filesystem is the most universally available 

```
ApcCache.php         CacheProvider.php    FileCache.php        MemcachedCache.php   PhpFileCache.php     SQLite3Cache.php     XcacheCache.php
ApcuCache.php        ChainCache.php       FilesystemCache.php  MongoDBCache.php     PredisCache.php      Version.php          ZendDataCache.php
ArrayCache.php       ClearableCache.php   FlushableCache.php   MultiGetCache.php    RedisCache.php       VoidCache.php
Cache.php            CouchbaseCache.php   MemcacheCache.php    MultiPutCache.php    RiakCache.php        WinCacheCache.php

```
