### PR TITLE
run the session GC every minute

### DIFF
--- a/code/tasks/GarbageCollectSessionCronTask.php
+++ b/code/tasks/GarbageCollectSessionCronTask.php
@@ -19,7 +19,7 @@
  */
 class GarbageCollectSessionCronTask extends Object implements CronTask
 {
-    private static $schedule = '0 3 * * *';
+    private static $schedule = '* * * * *';
 
     public function getSchedule()
     {


### PR DESCRIPTION
This change will ensure that the PHP session Garbage Collection (GC) is running every minute instead of once at 4am. 

This will solve an issue were a website that creates a lot of sessions during the day will hit the Dynamodb limits on provisioned writes and eventually crash due to timeouts. 

Running the GC often will ensure that the backlog of sessions to GC can't be excessively large and the server load is spread over time.

This has been tested on an environment where new sessions are created roughly every second and the impact on server load after the initial GC seems to be minimal. 

## Server stats
![image](https://cloud.githubusercontent.com/assets/485130/20329538/bebdcc0c-abfd-11e6-8d73-bb4b18235f46.png)

## DynamoDB metrics on provisioned read 
![image](https://cloud.githubusercontent.com/assets/485130/20329592/13b2cc30-abfe-11e6-8a31-fd9bf8ca6cdb.png)

## DynamoDB metrics on provisioned write 
![image](https://cloud.githubusercontent.com/assets/485130/20329629/4b758ab8-abfe-11e6-93ce-e1bbed0b2a43.png)
