### PR TITLE
Correct branch alias to 4.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"extra": {
 		"installer-name": "silverstripe-dynamodb",
 		"branch-alias": {
-			"dev-master": "3.0.x-dev"
+			"dev-master": "4.0.x-dev"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
master was tagged with 5983c4877b9d4518427e18685aff45cc9b136f6c on master already. The current state means you'll get a *newer* checkout with `composer require silverstripe/dynamodb:3.x-dev` than with `composer require silverstripe/dynamodb:^4`