### PR TITLE
DEP Update minimum version of aws/aws-sdk-php

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-  # Every Tuesday at 15:40 UTC
-  schedule:
-    - cron: '40 15 * * 2'
 
 jobs:
   ci:
     name: CI
-    # Only run cron on the silverstripe account
-    if: (github.event_name == 'schedule' && startsWith(github.repository, 'silverstripe/')) || (github.event_name != 'schedule')
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/.github/workflows/dispatch-ci.yml
+++ b/.github/workflows/dispatch-ci.yml
@@ -1,0 +1,16 @@
+name: Dispatch CI
+
+on:
+  # At 5:25 AM UTC, only on Tuesday and Wednesday
+  schedule:
+  - cron: '25 5 * * 2,3'
+
+jobs:
+  dispatch-ci:
+  name: Dispatch CI
+  # Only run cron on the silverstripe account
+  if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+  runs-on: ubuntu-latest
+  steps:
+    - name: Dispatch CI
+      uses: silverstripe/gha-dispatch-ci@v1

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ in EC2 instances, as credentials are automatically handled by the IAM role insid
 ```sh
 # The AWS access key and secret. This is optional if you've configured an instance with an IAM role
 # https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html
-AWS_ACCESS_KEY=my-access-key
-AWS_SECRET_KEY=my-secret
+# Note that AWS_ACCESS_KEY can only contain alphanumeric characters 
+# https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#DynamoDBLocal.DownloadingAndRunning.title
+AWS_ACCESS_KEY=myaccesskey
+AWS_SECRET_KEY=mysecret
 ```
 
 ## Local Testing
@@ -57,10 +59,10 @@ You can simulate DynamoDB locally for easier development through [DynamoDB Local
 Set environment constants. Note that actual access keys and regions are ignored,
 they just need to be defined.
 
-```sh
+```bash
 AWS_DYNAMODB_SESSION_TABLE=mysession
-AWS_ACCESS_KEY=my-access-key
-AWS_SECRET_KEY=my-secret
+AWS_ACCESS_KEY=myaccesskey
+AWS_SECRET_KEY=mysecret
 AWS_DYNAMODB_ENDPOINT=http://localhost:8000
 AWS_REGION_NAME=ap-southeast-2
 ```
@@ -70,6 +72,16 @@ and start it - it'll be available under `http://localhost:8000`.
 
 Now use the [AWS CLI Tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 to interact with your local DynamoDB.
+
+Configure user (optional):
+
+You can configure a user to use with the AWS CLI tools. Use this if you are having issues with the environment variables being picked up.
+
+```bash
+aws configure set aws_access_key_id myaccesskey
+aws configure set aws_secret_access_key myaccesskey
+aws configure set default.region ap-southeast-2
+```
 
 Create table:
 

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         }
     ],
     "require": {
-        "aws/aws-sdk-php": "^3.105",
+        "aws/aws-sdk-php": "^3.281",
         "silverstripe/framework": "^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-dynamodb/issues/52

There are 3x commits here so do not squash merge

Updating the minimum version of aws/aws-sdk-php + phpunit to fix issues with the --prefer-lowest build https://github.com/emteknetnz/silverstripe-dynamodb/actions/runs/6106999747/job/16573142161

dispatch-ci was updated using module-standardiser - there's a PR for that linked in the parent issue

Requires https://github.com/silverstripe/gha-ci/pull/87 to be merged first for CI to pass
