### PR TITLE
FIX Don't let dynamodb handler be overridden by default one

### DIFF
--- a/code/Model/DynamoDbSession.php
+++ b/code/Model/DynamoDbSession.php
@@ -7,6 +7,7 @@ use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\SessionHandler;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Control\Session;
+use SilverStripe\Control\SessionHandler\FileSessionHandler;
 use SilverStripe\Core\Environment;
 
 class DynamoDbSession
@@ -103,6 +104,11 @@ class DynamoDbSession
      */
     public function register()
     {
+        // Silverstripe CMS 6.1 introduced a new way to handle session handlers.
+        // We need to set that configuration to `null` so our handler isn't replaced.
+        if (class_exists(FileSessionHandler::class)) {
+            Session::config()->set('save_handler', null);
+        }
         return $this->handler->register();
     }
 }


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-dynamodb/pull/75

Overrides session save handler configuration when registering the dynamo db handler.

While setting configuration at runtime is generally a bad idea, this is the least invasive way to make this change. Otherwise we would likely need to tell developers to set this configuration in their own YAML config which would make it technically a breaking change.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11671